### PR TITLE
Make some more fields publicly accessible

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 use bitcoind::bitcoincore_rpc::Client;
-use bitcoind::BitcoinD;
+use bitcoind::{BitcoinD, ConnectParams};
 use std::ffi::OsStr;
 use std::fmt;
 
@@ -98,6 +98,10 @@ impl ElementsD {
 
     pub fn client(&self) -> &Client {
         &self.0.client
+    }
+
+    pub fn params(&self) -> &ConnectParams {
+        &self.0.params
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ mod versions;
 pub struct ElementsD(BitcoinD);
 
 #[non_exhaustive]
-pub struct Conf<'a>(bitcoind::Conf<'a>);
+pub struct Conf<'a>(pub bitcoind::Conf<'a>);
 
 /// All the possible error in this crate
 pub enum Error {


### PR DESCRIPTION
c5c802314ca96bad43a968a89e87fd98ed5ece22 is needed to make it possible to set custom config options for the elementsd daemon.

86d9c3d480f72963c81671705ac84af89d4d1b4b makes it possible to access the connect parameters.